### PR TITLE
[#4] Invalid github url in pull request template file. 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-https://github.com/nimble/git-template/issues/??
+https://github.com/nimbl3/git-template/issues/??
 
 ## What happened
 


### PR DESCRIPTION
https://github.com/nimble/git-template/issues/1

## What happened
- Regarding to issue #4 , pull request template has invalid nimbl3 github url.  
 
## Insight
- I update github url from nimble to nimbl3.