### PR TITLE
Rename node-modules to node_modules in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /.idea
 /coverage/
 /InstalledFiles
-/node-modules
+/node_modules
 /pkg/
 /spec/reports/
 /spec/examples.txt


### PR DESCRIPTION
## What happened 👀

`node-modules` is renamed to `node_modules` in `.gitignore`
 
## Insight 📝

N/A
 
## Proof Of Work 📹

`node-modules` is renamed to `node_modules`