### PR TITLE
[#22] Add Gitlab merge request templates

### DIFF
--- a/.gitlab/merge_request_templates/Default.md
+++ b/.gitlab/merge_request_templates/Default.md
@@ -1,0 +1,20 @@
+{COPY THE TASK URL HERE}
+
+## What happened 👀
+
+Describe the big picture of your changes here to communicate to the team why we should accept this pull request.
+
+## Insight 📝
+
+Describe in detail how to test the changes, which solution you tried but did not go with, referenced documentation is welcome as well.
+
+## Proof Of Work 📹
+
+Show us the implementation: screenshots, GIFs, etc.
+
+## Reviewers ✅
+
+Mention the reviewers here once the merge request is ready for review.
+
+<!-- Base labels. -->
+/label ~"status : wip"

--- a/.gitlab/merge_request_templates/Release.md
+++ b/.gitlab/merge_request_templates/Release.md
@@ -1,0 +1,22 @@
+## Features
+
+Provide the ID and title of each issue in the section for each type (feature, chore and bug). The link is optional.
+
+- [{ISSUE ID}] {ISSUE TITLE}
+or
+- [[{ISSUE ID}]]({ISSUE LINK})] {ISSUE TITLE}
+
+## Chores
+
+- Same structure as in  ## Feature
+
+## Bugs
+
+- Same structure as in  ## Feature
+
+## Reviewers ✅
+
+Mention the reviewers here once the merge request is ready for review.
+
+<!-- Base labels. -->
+/label ~"type : release"


### PR DESCRIPTION
Closes https://github.com/nimblehq/git-template/issues/22

## What happened 👀

Add .gitlab folder with merge request templates

## Insight 📝

Tags (`status : wip` and `type : release`) are automatically added.

The **Reviewers** section is here to substitute the capability to select multiple reviewers (yeah, this is only included in the paid-tier version of GitLab :harold:).

## Proof Of Work 📹

| Default template for Merge Request | Release template |
|---|---|
| ![image](https://user-images.githubusercontent.com/77609814/161481631-98d0407e-494d-446b-9165-1d150e6bc16a.png)|![image](https://user-images.githubusercontent.com/77609814/161481669-8a5cd7f0-8355-487e-8081-996ff666de68.png)|
