### PR TITLE
Fix copyright missing author

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Clone the repository
 
 ## License
 
-This project is Copyright (c) 2014 and onwards. It is free software and may be redistributed under the terms specified in the [LICENSE] file.
+This project is Copyright (c) 2014 and onwards Nimble. It is free software and may be redistributed under the terms specified in the [LICENSE] file.
 
 [LICENSE]: /LICENSE
 


### PR DESCRIPTION
## What happened 👀

Just added `Nimble` after `This project is Copyright (c) 2014 and onwards`.

## Insight 📝

`N/A`

## Proof Of Work 📹

`N/A`