### PR TITLE
Support light/dark logo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ This project is Copyright (c) 2014 and onwards Nimble. It is free software and m
 [LICENSE]: /LICENSE
 
 ## About
-
-![Nimble](https://assets.nimblehq.co/logo/dark/logo-dark-text-160.png)
+<a href="https://nimblehq.co/">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://assets.nimblehq.co/logo/dark/logo-dark-text-160.png">
+    <img alt="Nimble logo" src="https://assets.nimblehq.co/logo/light/logo-light-text-160.png">
+  </picture>    
+</a>
 
 This project is maintained and funded by Nimble.
 


### PR DESCRIPTION
## What happened 👀

Supporting light/dark logo to our README template.

## Insight 📝

Streamlining the changes from this https://github.com/nimblehq/.github/pull/1

## Proof Of Work 📹

Light:
<img src="https://user-images.githubusercontent.com/13435717/173487281-b4b95ad9-8fa2-4671-8e0a-6591ef387019.png" width=400 />

Dark:
<img src="https://user-images.githubusercontent.com/13435717/173487308-b0f71bbe-ef12-4f35-a2b9-8f2868fb68cf.png" width=400 />

