### PR TITLE
Support light/dark logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ This project is Copyright (c) 2014 and onwards Nimble. It is free software and m
 
 ## About
 
-![Nimble](https://assets.nimblehq.co/logo/dark/logo-dark-text-160.png)
+<a href="https://nimblehq.co/">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://assets.nimblehq.co/logo/dark/logo-dark-text-160.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://assets.nimblehq.co/logo/light/logo-light-text-160.png">
+    <img alt="Nimble" src="https://assets.nimblehq.co/logo/light/logo-light-text-160.png">
+  </picture>
+</a>
 
 This project is maintained and funded by Nimble.
 


### PR DESCRIPTION
## What happened 👀

Update the template to support both the Light/Dark logo

## Insight 📝

- Follow [Github documentation](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to)
- Change to use the `picture` tag because the appending (#gh-dark-mode-only or #gh-light-mode-only) is deprecated.

## Proof Of Work 📹

![2022-06-14 10 37 56](https://user-images.githubusercontent.com/7344405/173488364-c96279cd-919f-4907-8244-607acdde7dfc.gif)

