### PR TITLE
Add wiki workflow

### DIFF
--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -1,0 +1,18 @@
+name: Publish Wiki
+
+on:
+  push:
+    paths:
+      - .github/wiki/**
+    branches:
+      - develop
+
+jobs:
+  publish:
+    name: Publish Wiki
+    uses: nimblehq/github-actions-workflows/.github/workflows/publish_wiki.yml@0.1.0
+    with:
+      USER_NAME: github-wiki-workflow
+      USER_EMAIL: ${{ secrets.GH_EMAIL }}
+    secrets:
+      USER_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -1,3 +1,4 @@
+# For setup instruction, refer to https://github.com/nimblehq/github-actions-workflows/blob/main/.github/workflows/publish_wiki.yml
 name: Publish Wiki
 
 on:


### PR DESCRIPTION
## What happened 👀

- Add the [shared wiki workflow](https://github.com/nimblehq/github-actions-workflows/blob/develop/.github/workflows/publish_wiki.yml).
- Add the directory `.github/wiki` as a placeholder for all documentation.

## Insight 📝

Since most internal projects should be initialized with this template repository, adding the wikie workflow would ensure every internal project has the adequate setup.

## Proof Of Work 📹

The workflow is implemented as it is used on [the Rails template](https://github.com/nimblehq/rails-templates/blob/develop/.template/addons/github/.github/workflows/publish_wiki.yml.tt) or [the Elixir templates](https://github.com/nimblehq/elixir-templates/blob/develop/priv/templates/nimble_template/.github/workflows/publish_wiki.yml).