### PR TITLE
[#39] Fix can not detect branch name while rebasing

### DIFF
--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -7,7 +7,7 @@
 # feature/gh-1234-as-a-user-i-can-sigh-in => [#1234] Commit Message
 ##############################################################################################
 
-BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD | grep -E 'sc-\d+|gh-\d+' -o)"
+BRANCH_NAME="$(git branch | grep '*' | grep -E 'sc-\d+|gh-\d+' -o)"
 
 # Check if the branch name starts with 'sc-' followed by one or more digits using =~
 if [[ $BRANCH_NAME =~ ^sc-([0-9]+) ]]; then

--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -7,6 +7,8 @@
 # feature/gh-1234-as-a-user-i-can-sigh-in => [#1234] Commit Message
 ##############################################################################################
 
+# using `branch | grep '*'` instead of `git rev-parse --abbrev-ref HEAD` to ensure it works even when the HEAD
+# is not pointing to the branch tip (e.g. during interactive rebasing)
 BRANCH_NAME="$(git branch | grep '*' | grep -E 'sc-\d+|gh-\d+' -o)"
 
 # Check if the branch name starts with 'sc-' followed by one or more digits using =~


### PR DESCRIPTION
[Improve git commit-msg hook](https://github.com/nimblehq/git-template/issues/39)

The current solution to get the branch name git rev-parse --abbrev-ref HEAD only works if the HEAD is pointing the branch tip. This is not always true, i.e. while rebasing interactively

## What happened 👀

Fix bug: git commit message hook doesn't work while rewording commit in rebase session

## Insight 📝

Switch branch name detection implementation, from:
```
git rev-parse --abbrev-ref HEAD
```

to:
```
git branch | grep '*'
```

## Proof Of Work 📹

Before

https://github.com/nimblehq/git-template/assets/35915460/fe81820c-49b6-4c89-ab58-b3b9031973f8


After

https://github.com/nimblehq/git-template/assets/35915460/af71f3d8-bd7a-4143-acb0-330ad067cf13

