### PR TITLE
[#37] Support multi-line messages with git commit msg hook

### DIFF
--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -21,5 +21,12 @@ FIRSTLINE=$(head -n1 $1)
 
 # Check if the prefix '[sc-1234]' or '#1234' does NOT already exist at the beginning of the commit message using grep
 if grep -vqF $PREFIX <<< $FIRSTLINE; then
-  echo "$PREFIX $FIRSTLINE" > "$1"
+  # The -i option (edit in-place) behaves differently on OSX and Linux
+  # To not create backup file:
+  # OSX: sed -i '' expression file
+  # Linux: sed -i expression file
+  # See: https://unix.stackexchange.com/questions/13711/differences-between-sed-on-mac-osx-and-other-standard-sed/131940#131940:~:text=%2Di%20%27%27%20works,to%20sed).
+  # This is a work-around for that
+  PATCHED=$(sed "1 s/^.*$/$PREFIX $FIRSTLINE/" "$1")
+  echo "$PATCHED" > "$1"
 fi


### PR DESCRIPTION
Closes https://github.com/nimblehq/git-template/issues/39

## What happened 👀

Support multi-line message

## Insight 📝

- Use sed to replace first line of the commit message
- sed [behaves differently on OSX and Linux](https://unix.stackexchange.com/questions/13711/differences-between-sed-on-mac-osx-and-other-standard-sed/131940#131940:~:text=%2Di%20%27%27%20works,to%20sed). This PR uses a work-around for that

## Proof Of Work 📹

Before

https://github.com/nimblehq/git-template/assets/35915460/51c461f8-88a1-4d93-829c-a5488abcf345

After

https://github.com/nimblehq/git-template/assets/35915460/ef92ab19-c68c-43f1-8542-afa7b5f2c6a4