### PR TITLE
[Bug ]Fix git commit message hook: handle commit message with slashes

### DIFF
--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -50,6 +50,6 @@ if grep -vqF $PREFIX <<< $FIRSTLINE; then
   # Linux: sed -i expression file
   # See: https://unix.stackexchange.com/questions/13711/differences-between-sed-on-mac-osx-and-other-standard-sed/131940#131940:~:text=%2Di%20%27%27%20works,to%20sed).
   # This is a work-around for that
-  PATCHED=$(sed "1 s/^.*$/$PREFIX $FIRSTLINE/" "$1")
+  PATCHED=$(sed "1 s/^/$PREFIX /" "$1")
   echo "$PATCHED" > "$1"
 fi


### PR DESCRIPTION
## What happened 👀

- Fix a commit message hook bug

## Insight 📝

Previously, if a commit message contains slashes, it will break the sed command. For example, the commit message `one/two` will result in this invalid sed command:

```
sed -i '1 s/^.+$/sc-123 one/two/'
```

This fixes it by using a simple sed command. It simply appends to the first line

```
sed -i '1 s/^/sc-123'
```

> [!NOTE] 
> This implementation still error if the prefix contains some special character (sc/123). However, given our current prefix seems to follow the format `project-ticket_number` and also escaping the input string for sed is likely complex, I think this approach is acceptable

## Proof Of Work 📹

Before|After
-|-
![Screenshot 2023-11-24 at 17 00 26](https://github.com/nimblehq/git-template/assets/35915460/58fff88d-090b-41cd-91c0-380cf6f723c8)|![Screenshot 2023-11-24 at 17 01 03](https://github.com/nimblehq/git-template/assets/35915460/d74f4ee1-64b2-40bd-a8ec-dd674d6e7f44)



