### PR TITLE
[#47] Fix git commit-msg when the branch name has a second matching g…

### DIFF
--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -26,7 +26,7 @@
 
 # using `branch | grep '*'` instead of `git rev-parse --abbrev-ref HEAD` to ensure it works even when the HEAD
 # is not pointing to the branch tip (e.g. during interactive rebasing)
-SHORT_BRANCH_NAME="$(git branch | grep '*' | grep -E '\/(gh-\d+|(\w+)-\d+)' -o)"
+SHORT_BRANCH_NAME="$(git branch | grep '*' | grep -E '\/(gh-\d+|(\w+)-\d+)' -o | head -1)"
 
 # Extract the story ID from the branch name
 STORY_ID=${SHORT_BRANCH_NAME##*/}


### PR DESCRIPTION
- Close #47

## What happened 👀

Just add `| head -1`.

## Insight 📝

Solution source: https://stackoverflow.com/a/14093511/1914241

## Proof Of Work 📹

Before: 2 results

<img width="618" alt="image" src="https://github.com/nimblehq/git-template/assets/77609814/378e26d5-cafd-4ed3-bf4a-41ab30157076">

After: single result
<img width="646" alt="image" src="https://github.com/nimblehq/git-template/assets/77609814/3d571fc3-1fd8-476c-94d6-7defa14e805d">
