### PR TITLE
[#51] Update publishing wiki workflow to use actions/checkout@v6

### DIFF
--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 


### PR DESCRIPTION
- Close #51

## What happened 👀

Updated the publishing wiki workflow to use `actions/checkout@v6` instead of `actions/checkout@v3`.

## Insight 📝

GitHub Actions `actions/checkout@v3` is outdated. Upgrading to `v6` ensures compatibility with the latest runner environments and security updates.

## Proof Of Work 📹

N/A